### PR TITLE
Mention RLE++ encoding and reducing payload count by more than total number of duplicate payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Updated goals based on newer mainnet data and clarification about RAM:
 
 In progress... (so far, all results are better than the stated goals).
 
-There were ~77 million duplicate payloads in the older mainnet snapshot, and migration reduced payload count by ~86 million payloads. (TODO: update this using latest Oct 2025 mainnet snapshot)
+The new data format is designed to allow us to reduce more payloads than the total number of duplicate payloads.
+
+Test results based on Oct 1, 2025 mainnet snapshot show there are ~77 million duplicate payloads and migration reduces payload count by over 86 million payloads (not a typo).
 
 Most accounts on mainnet only have 1 account key but they still use fewer bytes in the new data format.
 
@@ -41,7 +43,8 @@ Most accounts on mainnet only have 1 account key but they still use fewer bytes 
 
 - ### Efficiently Detecting Duplicates At Runtime
 
-- ### RLP++ Encoding (I don't know if I'm the first person to invent this encoding)
+- ### RLE++ Encoding (I don't know if I'm the first person to invent this encoding)
+  - RLE++ supports RLE ([run-length encoding](https://en.wikipedia.org/wiki/Run-length_encoding)) and adds another feature that can be used together in the same encoding.
 
 ## Results of Optimized Migration Speed
 


### PR DESCRIPTION
Add placeholder for RLE++ encoding (I don't know if I'm first to invent it).  I named it RLE++ because it adds a feature to regular RLE (run-length encoding) that allows efficient encoding of data that is not repeating.

Mention test migration using Oct. 1, 2025 mainnet snapshot show ~77 million duplicate payloads and migration to new data format reduces number of payloads by over 86 million (not a typo).

Mention the new data format design allows us to remove more payloads than the total number of duplicate payloads.